### PR TITLE
Increases linearGradient version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/tomzaku/react-native-shimmer-placeholder#readme",
   "dependencies": {
-    "react-native-linear-gradient": "^2.0.0",
+    "react-native-linear-gradient": "2.2.0",
     "prop-types": "15.6.0"
   }
 }


### PR DESCRIPTION
By upgrading to latest version of `react-native-linear-gradient`, this commit fixes the Android build error below on latest versions of RN.

```
LinearGradientPackage.java:20: error: method does not override or implement a method from a supertype
    @Override
    ^
1 error
:react-native-linear-gradient:compileReleaseJavaWithJavac FAILED

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':react-native-linear-gradient:compileReleaseJavaWithJavac'.
> Compilation failed; see the compiler error output for details.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 30.114 secs
```