### PR TITLE
Fixing error: of type NSMutableDictionary cannot be converted to a YGValue.

### DIFF
--- a/ShimmerPlaceholder.js
+++ b/ShimmerPlaceholder.js
@@ -11,11 +11,11 @@ class CustomLinearGradient extends Component {
       <LinearGradient
         colors={colorShimmer}
         style={{ flex: 1 }}
-        start={{
+        startPoint={{
           x: -1,
           y: 0.5,
         }}
-        end={{
+        endPoint={{
           x: 2,
           y: 0.5,
         }}

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/tomzaku/react-native-shimmer-placeholder#readme",
   "dependencies": {
-    "react-native-linear-gradient": "2.2.0",
+    "react-native-linear-gradient": "2.4.0",
     "prop-types": "15.6.0"
   }
 }


### PR DESCRIPTION
https://github.com/react-native-community/react-native-linear-gradient/commit/a77528523e34be6e91a9fe642ab67ceb04e8e0ae

value '{
    x = 0;
    y = 0;
}' of type NSMutableDictionary cannot be converted to a YGValue.