### PR TITLE
Support for running inside Expo

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ Placeholder for both IOS and Android
 ### Installation
 #### Step 1: Install react-native-linear-gradient (dependence)
 
+**Note** : If you're using [Expo](https://expo.io) you *don't need* to install `react-native-linear-gradient`, you can ignore this step
+
 `npm i react-native-linear-gradient --save && react-native link react-native-linear-gradient`
 
 or

--- a/ShimmerPlaceholder.js
+++ b/ShimmerPlaceholder.js
@@ -2,7 +2,14 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types'
 import { View, StyleSheet, Animated, Platform } from 'react-native';
-import LinearGradient from 'react-native-linear-gradient';
+
+// https://gist.github.com/FGRibreau/3135914
+function module_exist(name){
+  try{require(name);} catch(err){if(err.code === 'MODULE_NOT_FOUND'){return false;}}
+  return true;
+};
+
+const LinearGradient = module_exist( 'expo' ) ? require( 'expo' ).LinearGradient : require( 'react-native-linear-gradient' )
 
 class CustomLinearGradient extends Component {
   render() {


### PR DESCRIPTION
When using Expo, you can't load native modules without ejecting which kinda ruins the Expo experience.

Fortunately, Expo ships with it's own LinearGradient component.

With this commit, the LinearGradient will be loaded from Expo if Expo is installed, making it possible to use this module out-of-the-box in an Expo environment