### PR TITLE
Stopping the animation when unmounting

### DIFF
--- a/lib/ShimmerPlaceholder.js
+++ b/lib/ShimmerPlaceholder.js
@@ -7,8 +7,7 @@ import LinearGradient from "react-native-linear-gradient";
 // create a component
 class ShimmerPlaceHolder extends Component {
   constructor(props) {
-    super(props);
-    // this.beginShimmerPosition = new Animated.Value(-1);
+    super(props); 
     this.state = {
       visible: false,
       beginShimmerPosition: new Animated.Value(-1)
@@ -20,24 +19,25 @@ class ShimmerPlaceHolder extends Component {
       this.loopAnimated();
     }
   }
+  componentWillUnmount() {
+    const shimmerAnimated = this.getAnimated();
+    shimmerAnimated.stop();
+  }
   loopAnimated() {
     const shimmerAnimated = this.getAnimated();
     const { visible } = this.props;
-    shimmerAnimated.start(() => {
-      if (!visible) {
+    shimmerAnimated.start(({ finished }) => {
+      if (!visible && finished) {
         this.loopAnimated();
       }
     });
   }
   getAnimated = () => {
-    // this.state.color.setValue(0);
     this.state.beginShimmerPosition.setValue(-1);
     return Animated.timing(this.state.beginShimmerPosition, {
       toValue: 1,
       duration: this.props.duration,
       useNativeDriver: true
-      // easing: Easing.linear,
-      // delay: -400
     });
   };
   render() {
@@ -128,7 +128,6 @@ ShimmerPlaceHolder.defaultProps = {
 // define your styles
 const styles = StyleSheet.create({
   container: {
-    // flex: 1,
     overflow: "hidden"
   }
 });


### PR DESCRIPTION
### Overview

This PR is intended to stop the shimmer animation when the component gets unmounted.

#### Why?

TL;DR;... It never notifies the native UI thread that an animation ended, breaking apps that expect this to happen.

I stumbled upon this issue when using https://github.com/wix/detox on a project and testing a loading part of the app using shimmer loading. The problem is that the shimmer placeholder actually never stopped the animation. When just looking at the app, it seems to work ok, but when inspecting the native UI thread and listening to lifecycle changes, it starts to misbehave.

#### Solution

This PR is pretty simple. It accomplishes the intended behavior just by changing two thins
1. implement a componenWillUnmount and stop the shimmer animation
2. when looping, pay attention to the Animated callback args to see if the animation was stopped on purpose and prevent starting it again