### PR TITLE
Keeping specified border-radius on Android

### DIFF
--- a/lib/ShimmerPlaceholder.js
+++ b/lib/ShimmerPlaceholder.js
@@ -98,7 +98,7 @@ class ShimmerPlaceHolder extends Component {
                   bottom: -40,
                   right: -40,
                   left: -40,
-                  borderRadius: width / 2 + 40 / 2,
+                  borderRadius: style.borderRadius || (width / 2 + 40 / 2),
                   borderWidth: 40,
                   borderColor: backgroundColorBehindBorder
                 }}


### PR DESCRIPTION
Fixes #17.

The bug came from an overridden radius value on an Android specific
configuration.
This enables keeping it by default if the value was defined already.