### PR TITLE
Update index.d.ts (Fix ref attribute is missing)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -16,6 +16,6 @@ declare module 'react-native-shimmer-placeholder' {
         hasBorder?: boolean,
         isInteraction?: boolean,
     }
-    declare const MyComponent: React.SFC<Props>
+    declare class MyComponent extends React.Component<Props, any> {}
     export default MyComponent
 }


### PR DESCRIPTION
- react-native-shimmer-placeholder@1.0.32
- react-native@0.59.5
    - @types: ^0.57.43
- react@16.8.3
    - @types: ^16.8.14

In above environment, below code shows error when running typescript compiler (tsc).
```
error TS2322: Type '{ ref: (ref: any) => number; style: ViewStyle; }' is not assignable to type 'IntrinsicAttributes & Props & { children?: ReactNode; }'.
  Property 'ref' does not exist on type 'IntrinsicAttributes & Props & { children?: ReactNode; }'.

30         <ShimmerPlaceHolder ref={(ref) => this.animationRefs.push(ref)} style={styles.booklistImage} />
            ~~~~~~~~~~~~~~~~~~
```

In this project's d.ts file defined `ShimmerPlaceHolder` as SFC but it doesn't have ref attribute.
This PR resolve this issue.