### PR TITLE
Add getAnimated to TS types (and use interface)

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,21 +1,23 @@
 declare module 'react-native-shimmer-placeholder' {
     import React from 'react';
-    type Props = {
-        width?: number | string,
-        height?: number | string,
-        widthShimmer?: number,
-        duration?: number,
-        delay?: number,
-        colorShimmer?: string[],
-        reverse?: boolean,
-        autoRun?: boolean,
-        visible?: boolean,
-        children?: any,
-        style?: any,
-        backgroundColorBehindBorder?: string,
-        hasBorder?: boolean,
-        isInteraction?: boolean,
+    import { Animated } from 'react-native';
+    interface Props {
+        width?: number | string;
+        height?: number | string;
+        widthShimmer?: number;
+        duration?: number;
+        delay?: number;
+        colorShimmer?: string[];
+        reverse?: boolean;
+        autoRun?: boolean;
+        visible?: boolean;
+        children?: any;
+        style?: any;
+        backgroundColorBehindBorder?: string;
+        hasBorder?: boolean;
+        isInteraction?: boolean;
     }
-    declare class MyComponent extends React.Component<Props, any> {}
-    export default MyComponent
+    export default class ShimmerPlaceHolder extends React.Component<Props, any> {
+        getAnimated(): Animated.CompositeAnimation;
+    }
 }


### PR DESCRIPTION
TS typings are missing `getAnimated` method. So it is not possible to use it with `React.createRef<ShimmerPlaceHolder>();`

This changes fixes it.

I also changed `Props` to use interface, and declare class without using `declare` (should fix #31).