### PR TITLE
[FIX] Shimmer Animation not running after re-render

### DIFF
--- a/lib/ShimmerPlaceholder.js
+++ b/lib/ShimmerPlaceholder.js
@@ -60,6 +60,8 @@ class ShimmerPlaceHolder extends Component {
     if (reverse) {
       outputRange = outputRange.reverse();
     }
+
+    this.loopAnimated();
     const linearTranslate = this.state.beginShimmerPosition.interpolate({
       inputRange: [-1, 1],
       outputRange: outputRange


### PR DESCRIPTION
**In our main component using like this**

`<ShimmerPlaceHolder
          autoRun={true}
          visible={!this.state.loading}
        >
          <Typography type={'title-1'}>Testing</Typography>
        </ShimmerPlaceHolder>`

if the loading state changes to false again, the placeholder background is visible and children are hidden but the shimmer animation doesn't work.

This is possibly due to not cleaning the animation state on re-render. Calling the loopAnimated function on re-rendering fixes the issue.