### PR TITLE
Add testID for easier testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,22 +134,25 @@ More Detail see [this](https://github.com/tomzaku/react-native-shimmer-placehold
 
 ### Props
 
-| Prop                      | Description                                                                                            | Type      | Default                                           |
-| ------------------------- | ------------------------------------------------------------------------------------------------------ | --------- | ------------------------------------------------- |
-| **`LinearGradient`**      | Linear Gradient components ('react-native-linear-gradient' or 'expo-linear-gradient')                  | Component | global.Expo.LinearGradient                        |
-| **`visible`**             | Visible child components                                                                               | boolean   | false                                             |
-| **`style`**               | Container Style                                                                                        | Style     | `{backgroundColor: '#ebebeb',overflow: 'hidden'}` |
-| **`shimmerStyle`**        | Shimmer Style only                                                                                     | Style     | {}                                                |
-| **`contentStyle`**        | Content Style when visible                                                                             | Style     | {}                                                |
-| **`location`**            | Locations of shimmer                                                                                   | number[]  | *[0.3, 0.5, 0.7]*                                 |
-| **`width`**               | Width of row                                                                                           | number    | 200                                               |
-| **`duration`**            | Duration of shimmer over a row                                                                         | number    | 1000                                              |
-| **`height`**              | Height of row                                                                                          | number    | 15                                                |
-| **`shimmerWidthPercent`** | Percent of shimmer width                                                                               | number    | 1.0                                               |
-| **`isReversed`**          | Reverse direction of animation                                                                         | boolean   | `false`                                           |
-| **`stopAutoRun`**         | Stop running shimmer animation at beginning                                                            | boolean   | `false`                                           |
-| **`isInteraction`**       | Defines whether or not the shimmer animation creates an interaction handle on the `InteractionManager` | boolean   | `true`                                            |
-| **`shimmerColors`**       | Colors of the shimmer.                                                                                 | string[]  | *['#ebebeb', '#c5c5c5', '#ebebeb']*               |
+| Prop                         | Description                                                                                            | Type      | Default                                           |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------ | --------- | ------------------------------------------------- |
+| **`LinearGradient`**         | Linear Gradient components ('react-native-linear-gradient' or 'expo-linear-gradient')                  | Component | global.Expo.LinearGradient                        |
+| **`visible`**                | Visible child components                                                                               | boolean   | false                                             |
+| **`style`**                  | Container Style                                                                                        | Style     | `{backgroundColor: '#ebebeb',overflow: 'hidden'}` |
+| **`shimmerStyle`**           | Shimmer Style only                                                                                     | Style     | {}                                                |
+| **`contentStyle`**           | Content Style when visible                                                                             | Style     | {}                                                |
+| **`location`**               | Locations of shimmer                                                                                   | number[]  | *[0.3, 0.5, 0.7]*                                 |
+| **`width`**                  | Width of row                                                                                           | number    | 200                                               |
+| **`duration`**               | Duration of shimmer over a row                                                                         | number    | 1000                                              |
+| **`height`**                 | Height of row                                                                                          | number    | 15                                                |
+| **`shimmerWidthPercent`**    | Percent of shimmer width                                                                               | number    | 1.0                                               |
+| **`isReversed`**             | Reverse direction of animation                                                                         | boolean   | `false`                                           |
+| **`stopAutoRun`**            | Stop running shimmer animation at beginning                                                            | boolean   | `false`                                           |
+| **`isInteraction`**          | Defines whether or not the shimmer animation creates an interaction handle on the `InteractionManager` | boolean   | `true`                                            |
+| **`shimmerColors`**          | Colors of the shimmer.                                                                                 | string[]  | *['#ebebeb', '#c5c5c5', '#ebebeb']*               |
+| **`containerProps`**         | Props passed to the outermost View                                                                     | ViewProps | undefined                                         |
+| **`shimmerContainerProps`**  | Props passed to the View which contains the loading animation                                          | ViewProps | undefined                                         |
+| **`childrenContainerProps`** | Props passed to the View which contains the children                                                   | ViewProps | undefined                                         |
 
 ### Methods
 | Method            | Description                 | Type     |

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,9 @@
 declare module 'react-native-shimmer-placeholder' {
 
     import * as React from 'react';
-    import { Animated } from 'react-native';
+    import { Animated, ViewProps } from 'react-native';
 
-    export interface ShimmerPlaceholderProps {
+    export interface ShimmerPlaceholderProps extends ViewProps {
         width?: number | string;
         height?: number | string;
         shimmerWidthPercent?: number;
@@ -19,7 +19,6 @@ declare module 'react-native-shimmer-placeholder' {
         contentStyle?: any;
         isInteraction?: boolean;
         LinearGradient?: React.ComponentClass<any>;
-        testID?: string;
     }
 
     class ShimmerPlaceholder extends React.Component<ShimmerPlaceholderProps, any> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -3,7 +3,7 @@ declare module 'react-native-shimmer-placeholder' {
     import * as React from 'react';
     import { Animated, ViewProps } from 'react-native';
 
-    export interface ShimmerPlaceholderProps extends ViewProps {
+    export interface ShimmerPlaceholderProps {
         width?: number | string;
         height?: number | string;
         shimmerWidthPercent?: number;
@@ -19,6 +19,9 @@ declare module 'react-native-shimmer-placeholder' {
         contentStyle?: any;
         isInteraction?: boolean;
         LinearGradient?: React.ComponentClass<any>;
+        containerProps?: ViewProps
+        shimmerContainerProps?: ViewProps
+        childrenContainerProps?: ViewProps
     }
 
     class ShimmerPlaceholder extends React.Component<ShimmerPlaceholderProps, any> {

--- a/index.d.ts
+++ b/index.d.ts
@@ -19,6 +19,7 @@ declare module 'react-native-shimmer-placeholder' {
         contentStyle?: any;
         isInteraction?: boolean;
         LinearGradient?: React.ComponentClass<any>;
+        testID?: string;
     }
 
     class ShimmerPlaceholder extends React.Component<ShimmerPlaceholderProps, any> {

--- a/lib/ShimmerPlaceholder.js
+++ b/lib/ShimmerPlaceholder.js
@@ -54,6 +54,7 @@ const BasedShimmerPlaceholder = (props) => {
     animatedValue,
     beginShimmerPosition,
     shimmerWidthPercent = 1,
+    testID
   } = props
 
   const linearTranslate = beginShimmerPosition.interpolate({
@@ -82,6 +83,7 @@ const BasedShimmerPlaceholder = (props) => {
   return (
     <View
       style={[!visible && { height, width }, styles.container, !visible && shimmerStyle, style]}
+      testID={testID}
     >
       {/* Force render children to restrict rendering twice */}
       <View style={[!visible && { width: 0, height: 0, opacity: 0 }, visible && contentStyle]}>{children}</View>

--- a/lib/ShimmerPlaceholder.js
+++ b/lib/ShimmerPlaceholder.js
@@ -54,7 +54,7 @@ const BasedShimmerPlaceholder = (props) => {
     animatedValue,
     beginShimmerPosition,
     shimmerWidthPercent = 1,
-    testID
+    ...restProps
   } = props
 
   const linearTranslate = beginShimmerPosition.interpolate({
@@ -83,7 +83,7 @@ const BasedShimmerPlaceholder = (props) => {
   return (
     <View
       style={[!visible && { height, width }, styles.container, !visible && shimmerStyle, style]}
-      testID={testID}
+      {...restProps}
     >
       {/* Force render children to restrict rendering twice */}
       <View style={[!visible && { width: 0, height: 0, opacity: 0 }, visible && contentStyle]}>{children}</View>

--- a/lib/ShimmerPlaceholder.js
+++ b/lib/ShimmerPlaceholder.js
@@ -54,7 +54,9 @@ const BasedShimmerPlaceholder = (props) => {
     animatedValue,
     beginShimmerPosition,
     shimmerWidthPercent = 1,
-    ...restProps
+    containerProps,
+    shimmerContainerProps,
+    childrenContainerProps
   } = props
 
   const linearTranslate = beginShimmerPosition.interpolate({
@@ -83,13 +85,18 @@ const BasedShimmerPlaceholder = (props) => {
   return (
     <View
       style={[!visible && { height, width }, styles.container, !visible && shimmerStyle, style]}
-      {...restProps}
+      {...containerProps}
     >
       {/* Force render children to restrict rendering twice */}
-      <View style={[!visible && { width: 0, height: 0, opacity: 0 }, visible && contentStyle]}>{children}</View>
+      <View
+        style={[!visible && { width: 0, height: 0, opacity: 0 }, visible && contentStyle]}
+        {...childrenContainerProps}
+      >
+        {children}
+      </View>
       {
         !visible && (
-          <View style={{ flex: 1, backgroundColor: shimmerColors[0] }}>
+          <View style={{ flex: 1, backgroundColor: shimmerColors[0] }} {...shimmerContainerProps}>
             <Animated.View
               style={{ flex: 1, transform: [{ translateX: linearTranslate }] }}
             >


### PR DESCRIPTION
Add optional `testID` string prop.

This enables the shimmer to be queried with [react-native-testing-library](https://github.com/callstack/react-native-testing-library) using the testID.
For example if we have a component which includes this JSX:
```typescript
export const ExampleComponent = () => {
  const { data, loading } = useSomeAsyncEffect()
  return (
    <>
      {loading && <ShimmerPlaceholder testID="loadingShimmer" />}
      {!loading && <Text>Some Text {data}</Text>}
    </>
  )
}
 ```
 We can then wait for all the shimmers to disappear before testing the component contents:
 ```typescript
 const { getByText, getAllByTestId } =  render(<ExampleComponent />)
 await waitForElementToBeRemoved(() => getAllByTestId('loadingShimmer'))
 getByText('Some Text')
 ```
 This makes it easy to test that shims are rendered and removed in the correct place and time.