### PR TITLE
Updated ShimmerPlaceholderProps interface to include optional location array

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -10,6 +10,7 @@ declare module 'react-native-shimmer-placeholder' {
         duration?: number;
         delay?: number;
         shimmerColors?: string[];
+        location?: number[];
         isReversed?: boolean;
         stopAutoRun?: boolean;
         visible?: boolean;


### PR DESCRIPTION
**Reported Issue: https://github.com/tomzaku/react-native-shimmer-placeholder/issues/70**

### Problem

The `BasedShimmerPlaceholder` defaults the `location` and `shimmerColors` props to: 
```ts
    shimmerColors = ["#ebebeb", "#c5c5c5", "#ebebeb"],
    location = [0.3, 0.5, 0.7],
```
If you pass in a custom length array of `shimmerColor` without the same length `location` array it results in the following warnings: 
```bash
 WARN  LinearGradient colors and locations props should be arrays of the same length 
```
<img src=https://user-images.githubusercontent.com/20522662/154820103-450eddaa-feb1-498b-a846-71934978339a.png width=300/>

### Solution

Updated the `ShimmerPlaceholderProps` interface to include an optional number array prop `location` to allow for custom length LinearGradient color array + location array which resolves the issue. 

