### PR TITLE
Set useNativeDriver=false on web to fix looping

### DIFF
--- a/lib/ShimmerPlaceholder.js
+++ b/lib/ShimmerPlaceholder.js
@@ -15,7 +15,7 @@ class ShimmerPlaceholder extends PureComponent {
         toValue: 1,
         delay,
         duration,
-        useNativeDriver: true,
+        useNativeDriver: Platform.OS !== "web",
         isInteraction,
       })
     );


### PR DESCRIPTION
Animated doesn't support useNativeDriver on web, resulting in animation loops breaking when set to true anyway.